### PR TITLE
modified get_reordering function in order to treat degenerate states.

### DIFF
--- a/src/reorder_matrices.py
+++ b/src/reorder_matrices.py
@@ -207,11 +207,13 @@ class Test_unavoided(unittest.TestCase):
 
         if p7 != perm_d:
             ksi = rnd.uniform(0.0,1.0)
-            ip = int(d.num_of_rows*ksi)
+            Np = len(perm_d)/d.num_of_rows # the number of permutations
+            ip = int(Np*ksi)
             istart = ip*d.num_of_rows
             iend = (ip+1)*d.num_of_rows
             ptmp = perm_d[istart:iend]
             reorder(ptmp,d,Ed); print "Matrix d is reordered"
+            print "ip is %i" % ip
         print "Output density matrix d"; d.show_matrix()
         print "Output energy matrix Ed"; Ed.show_matrix()
         print "Permutation d = ", perm_d

--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -86,7 +86,7 @@ def get_reordering(time_overlap):
             esc.extend(ind) # extract elements of ind, not the list itself.
             
             perm_mix.append(ind) # extract groups of mixed states, say, [[0,1][2,3][4,5]]
-            print perm_mix
+            #print perm_mix
 
     #print "indices for mixed states are"; print esc;
     #print "groups of mixed states are"; print perm_mix
@@ -98,6 +98,7 @@ def get_reordering(time_overlap):
 
         indx = -1
         val = 0.0+0.0j
+        cnt = 0
         if all((col!=x for x in esc)): # avoid indices of mixed states
             while indx!=col:
 
@@ -111,8 +112,11 @@ def get_reordering(time_overlap):
 
                 # Do the corresponding swap of the columns in the S matrix
                 S.swap_cols(col,indx)
-            
-    #sys.exit(0)
+
+                # check if this loop ends or not.
+                cnt+=1
+                if cnt > sz:
+                    sys.exit(0)
     #print "After being reordered, the working permutation is"; print perm_wrk
 
     ''' Then, all posible permutations will be generated. '''

--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -116,7 +116,10 @@ def get_reordering(time_overlap):
                 # check if this loop ends or not.
                 cnt+=1
                 if cnt > sz:
-                    sys.exit(0)
+                    print "reordering counts reached the given threshold "
+                    print "The matrix is "; S.show_matrix();
+                    print "The (col,indx) pair is (%i,%i)" % (col,indx)
+                    print "exitting..."; sys.exit(0)
     #print "After being reordered, the working permutation is"; print perm_wrk
 
     ''' Then, all posible permutations will be generated. '''

--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -339,7 +339,7 @@ class TestUnavoided(unittest.TestCase):
         perm_h1 = get_reordering(h1)
         print "Input matrix "; h1.show_matrix()
         print "Permutation = ", perm_h1
-        perm_h1_eq = [0, 1, 2, 3, 4, 0, 1, 3, 2, 4, 0, 2, 1, 3, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 3, 2, 1, 4]
+        perm_h1_eq = [0, 1, 2, 3, 4, 0, 3, 2, 1, 4, 0, 1, 3, 2, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 2, 1, 3, 4]
         self.assertEqual(perm_h1, perm_h1_eq)
 
 if __name__=='__main__':

--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -82,6 +82,15 @@ def get_reordering(time_overlap):
         #print "duplicate numbers are"; print du
         for dnum in du:
             ind = [ i for i , x in enumerate(perm_ini) if dnum == x] # extract indices related to duplication
+
+            # extract the indices pointing the states related to duplication
+            ltmp = []
+            for i in xrange(len(perm_ini)):
+                x = perm_ini[i]
+                if x != dnum and x in ind: 
+                    ltmp.append(i)
+            ind.extend(ltmp)
+
             #print "mixed states are"; print ind
             esc.extend(ind) # extract elements of ind, not the list itself.
             
@@ -252,13 +261,41 @@ def _test_setup():
     g.set(5,5,0.77+0j); g.set(5,6,0.78+0j);
     g.set(6,5,0.79+0j); g.set(6,6,0.81+0j);
 
-    return a, b, c, d, e, f, g
+    # non-identical matrix (corresponding to triply mixed states)
+    # | 1    0    0    0 0 |
+    # | 0 0.77 0.78 0.65 0 |
+    # | 0 0.76 0.75 0.89 0 |
+    # | 0 0.65 0.54 0.77 0 |
+    # | 0    0    0    0 1 | 
+
+    h = CMATRIX(5,5)
+    h.set(0,0,1.0+0j);
+    h.set(1,1,0.77+0j); h.set(1,2,0.78+0j); h.set(1,3,0.65+0j);
+    h.set(2,1,0.76+0j); h.set(2,2,0.75+0j); h.set(2,3,0.89+0j);
+    h.set(3,1,0.65+0j); h.set(3,2,0.54+0j); h.set(3,3,0.77+0j);
+    h.set(4,4,1.00+0j);
+
+    # non-identical matrix (corresponding to triply mixed states)
+    # | 1    0    0    0 0 | 
+    # | 0 0.65 0.78 0.77 0 |
+    # | 0 0.89 0.75 0.76 0 |
+    # | 0 0.77 0.54 0.65 0 |
+    # | 0    0    0    0 1 |
+
+    h1 = CMATRIX(5,5)
+    h1.set(0,0,1.0+0j);
+    h1.set(1,3,0.77+0j); h1.set(1,2,0.78+0j); h1.set(1,1,0.65+0j);
+    h1.set(2,3,0.76+0j); h1.set(2,2,0.75+0j); h1.set(2,1,0.89+0j);
+    h1.set(3,3,0.65+0j); h1.set(3,2,0.54+0j); h1.set(3,1,0.77+0j);
+    h1.set(4,4,1.00+0j);
+
+    return a, b, c, d, e, f, g, h, h1
 
 
 class TestUnavoided(unittest.TestCase):
     def test_reordering(self):
         """Tests the reordering algorithm"""
-        a,b,c,d,e,f,g = _test_setup()
+        a,b,c,d,e,f,g,h, h1 = _test_setup()
 
         perm_a = get_reordering(a)
         print "Input matrix "; a.show_matrix()
@@ -292,6 +329,18 @@ class TestUnavoided(unittest.TestCase):
         perm_g_eq = [0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 6, 5, 0, 1, 2, 4, 3, 5, 6, 0, 1, 2, 4, 3, 6, 5,\
                          0, 2, 1, 3, 4, 5, 6, 0, 2, 1, 3, 4, 6, 5, 0, 2, 1, 4, 3, 5, 6, 0, 2, 1, 4, 3, 6, 5]
         self.assertEqual(perm_g, perm_g_eq)
+
+        perm_h = get_reordering(h)
+        print "Input matrix "; h.show_matrix()
+        print "Permutation = ", perm_h
+        perm_h_eq = [0, 1, 2, 3, 4, 0, 1, 3, 2, 4, 0, 2, 1, 3, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 3, 2, 1, 4]
+        self.assertEqual(perm_h, perm_h_eq)
+
+        perm_h1 = get_reordering(h1)
+        print "Input matrix "; h1.show_matrix()
+        print "Permutation = ", perm_h1
+        perm_h1_eq = [0, 1, 2, 3, 4, 0, 1, 3, 2, 4, 0, 2, 1, 3, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 3, 2, 1, 4]
+        self.assertEqual(perm_h1, perm_h1_eq)
 
 if __name__=='__main__':
     unittest.main()

--- a/src/x_to_libra_gms.py
+++ b/src/x_to_libra_gms.py
@@ -33,6 +33,7 @@ from moment import *
 from misc import *
 from spin_indx import *
 import reorder_matrices
+import unavoided_tmp # set temporally
 
 def exe_gamess(params):
     ##
@@ -86,6 +87,8 @@ def gamess_to_libra(params, ao, E, sd_basis, active_space,suff):
     nstates = len(params["excitations"])
     sz = len(active_space)
 
+    rnd = Random()
+
     # 2-nd file - time "t+dt"  new
     label, Q, R, Grad, E2, c2, ao2, nel = gms_extract(params["gms_out"],params["excitations"],params["min_shift"],active_space,params["debug_gms_unpack"])
 
@@ -122,12 +125,22 @@ def gamess_to_libra(params, ao, E, sd_basis, active_space,suff):
     #print "Time to compute in SD_overlap= ",t.show(),"sec"
 
     p0 = range(nstates)
-    perm = unavoided.get_reordering(P12) # 
+    #perm = unavoided.get_reordering(P12)
+    perm = unavoided_tmp.get_reordering(P12) # temporally
     if p0 != perm:
         print "trivial crossings occured!"
         print "perm is", perm
         print "P12 is"; P12.show_matrix()
-        reorder_matrices.reorder(perm,P12,E2)
+        ksi = rnd.uniform(0.0,1.0)
+        Np = len(perm)/nstates
+        ip = int(Np*ksi)
+        istart = ip*nstates
+        iend = (ip+1)*nstates
+        ptmp = perm[istart:iend]
+        print "The selected number is %i" % ip
+        print "selected permutation is "; print ptmp
+
+        reorder_matrices.reorder(ptmp,P12,E2)
         P21 = P12.H()
 
     # calculate transition dipole moment matrices in the MO basis:


### PR DESCRIPTION
This function can treat more patterns of degenerate states with the below lines:

  86 +            # extract the indices pointing the states related to duplication  
  87 +            ltmp = []  
  88 +            for i in xrange(len(perm_ini)):  
  89 +                x = perm_ini[i]  
  90 +                if x != dnum and x in ind:   
  91 +                    ltmp.append(i)  
  92 +            ind.extend(ltmp)  

Although this function can't treat all kind of matrices, this can reorder density matrices <phi_i(t)|phi_j(t+dt)>of my concern.

This function returns all possible permutations; one of them will be used to reorder matrices.