### PR TITLE
modified the reordering function using traces of density matrices.

### DIFF
--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -42,133 +42,72 @@ def get_reordering(time_overlap):
 
     \param[in] time_overlap ( MATRIX ) the time overlap matrix, <phi_i(t)|phi_j(t+dt)>.
     Returns:
-    perm - list of integers that describe all possible permutation. That is:
-    perm[i] - contains all possible permutations
-    (ex. [0,1,2,...,np-1,0,2,1,...,np-1,...],which can be divided into every "np".
-    "np" is assumed to be more than 1 if we have mixed states during calculation.)
-    In a permutation, say, [0,1,...,i-1,j,i+1,...], the index identifying the "older" state "i".
-    Now, it may be labeled by some other index, j. 
-    iperm[j] - if we were looking at a specific state labeled "j", iperm[j] this will be
-    the index of that state in the present list of states (e.g. energies, etc.)
+    perm - list of integers that describe permutation. That is:
+    j = perm[i] - this means older state i is coressponding to newer state j.
+    If i=j is satisfied with all (i,j) pairs, state mismatching doesn't occured,
+    otherwise, it occurs. we need to repair the mismatching in another function.
 
     """
 
-    # extract the indices where <phi_i(t)|phi_i(t+dt)> is not close to 1. 
+    # define variables
     S = CMATRIX(time_overlap)   # just a temporary working object
     sz = time_overlap.num_of_rows
-    #perm = range(sz)  # original permutation
-    perm_wrk = range(sz) # working permutation
+    perm = range(sz)  # original permutation
 
-    # Before getting indices for reordering, we must find ones pointing the same state.
-    # If we get a list [0,1,1,3],
-    # we find that new states 1 and 2 (starting from 0) will be assigned by old state 1.
-    # In this case, they are also close to old state 2.
-    # So, we have 2 permutations for transition: (1,2) or (2,1).
-
-    perm_ini = range(sz) # for storing initial indices 
+    # extract the indices of states related to trivial crossings or degeneration.
+    s_col_indx = set() 
     for col in xrange(sz):
         val = 0.0+0.0j
         # Find the max element in the given column "col"                                                                   
-        [perm_ini[col], val] = S.max_col_elt(col)
+        [indx, val] = S.max_col_elt(col)
+        if col != indx:
+            s_col_indx.add(col); s_col_indx.add(indx)
 
-    #print "pini is"; print pini
-    # create a list "du" including duplicate numbers
-    t = set()
-    du = list(set([x for x in perm_ini if x in t or t.add(x)])) 
+    s_col_indx = list(s_col_indx) # we need to use the indices: set object can't use it.
+    sz_indx = len(s_col_indx)
 
-    esc = [] # including indices of states for avoid reordering.
-    perm_mix = [] # including groups of indices related to mixed states. 
-    if len(du) > 0: # when duplication is found in pini
-        #print "duplicate numbers are"; print du
-        for dnum in du:
-            ind = [ i for i , x in enumerate(perm_ini) if dnum == x] # extract indices related to duplication
+    if sz_indx > 0: # trivial crossings occured!
 
-            # extract the indices pointing the states related to duplication
-            ltmp = []
-            for i in xrange(len(perm_ini)):
-                x = perm_ini[i]
-                if x != dnum and x in ind: 
-                    ltmp.append(i)
-            ind.extend(ltmp)
+        # define another matrix whose elements are absolute values of S elements. 
+        SS = MATRIX(sz,sz) # stores the absolute values of S elements.
+        for i in xrange(sz):
+            for j in xrange(sz):
+                SS.set(i,j, abs(S.get(i,j)))
 
-            #print "mixed states are"; print ind
-            esc.extend(ind) # extract elements of ind, not the list itself.
-            
-            perm_mix.append(ind) # extract groups of mixed states, say, [[0,1][2,3][4,5]]
-            #print perm_mix
+        # define a matrix storing the columns.
+        A = MATRIX(sz,sz_indx)
+        for i in xrange(sz):
+            for j in xrange(sz_indx):
+                A.set(i,j,SS.get(i,s_col_indx[j]))
 
-    #print "indices for mixed states are"; print esc;
-    #print "groups of mixed states are"; print perm_mix
+        # generate all possible permutations
+        perm_cand = list(itertools.permutations(s_col_indx))
+        cand_sz = len(perm_cand)
 
-    #sys.exit(0)
+        # detect the pemutation corresponding to the largest trace of all reordering patterns 
+        imax=-1; max_tr = 0;
+        for i in xrange(cand_sz):
+            for j in xrange(sz):
+                for k in xrange(sz_indx):
+                    SS.set(j,perm_cand[i][k],A.get(j,k))
+            if max_tr < SS.tr():
+                imax = i
+                max_tr = SS.tr()
 
-    ''' reordering part starts '''
-    for col in xrange(sz):
+        # make out how indices of newer states are corresponding to those of older ones. 
+        perm_res = s_col_indx[:]
+        for i in xrange(sz_indx):
+            ix = s_col_indx[i]
+            for j in xrange(sz_indx):
+              jx = perm_cand[imax][j]  
+              if ix == jx:
+                perm_res[i] = s_col_indx[j] 
 
-        indx = -1
-        val = 0.0+0.0j
-        cnt = 0
-        if all((col!=x for x in esc)): # avoid indices of mixed states
-            while indx!=col:
-
-                # Find the max element in the given column "col"
-                [indx, val] = S.max_col_elt(col)
-
-                # Apply permutation (col, indx) to the present "perm" list
-                tmp = perm_wrk[col]
-                perm_wrk[col] = perm_wrk[indx]
-                perm_wrk[indx] = tmp
-
-                # Do the corresponding swap of the columns in the S matrix
-                S.swap_cols(col,indx)
-
-                # check if this loop ends or not.
-                cnt+=1
-                if cnt > sz:
-                    print "***********************************************"
-                    print "reordering counts reached the given threshold "
-                    print "The original matrix is "; time_overlap.show_matrix();
-                    print "row numbers indicating maximum value of each column are"; print perm_ini;
-                    print "duplicate numbers are"; print du;
-                    print "column numbers for escaping from reordering are"; print esc;
-                    print "The reordered matrix is"; S.show_matrix();
-                    print "The (col,indx) pair occuring errors is (%i,%i)" % (col,indx)
-                    print "exitting..."; sys.exit(0)
-
-    #print "After being reordered, the working permutation is"; print perm_wrk
-
-    ''' Then, all posible permutations will be generated. '''
-
-    Nperm = 1 # number of permutations
-    for ip in perm_mix:
-        Nperm *= math.factorial(len(ip)) # in the case [[1,2][3,4]], Nperm=2!x2!=4
-    #print "number of permutations is %i" % Nperm
-
-    perm_g = [] # contains groups of permutations, say, [[(1,2),(2,1)][(3,4),(4,3)]]
-    for i in xrange(len(perm_mix)):
-        perm_g.append(list(itertools.permutations(perm_mix[i])))
-    #print "groups of permutations are "; print perm_g
-
-    perm_com = [] # contains combined permutations of perm_g, say,
-                  # [(1,2,3,4),(1,2,4,3),(2,1,3,4),(2,1,4,3)]
-    if len(perm_g) == 1:
-        for i in xrange(Nperm):
-            perm_com.append(perm_g[0][i]) 
-    if len(perm_g) > 1:
-        for i in xrange(len(perm_mix)-1):
-            ptmp = []
-            for j in xrange(len(perm_g[i])):
-                for k in xrange(len(perm_g[i+1])):
-                    ptmp.append(perm_g[i][j]+perm_g[i+1][k])
-            perm_g[i+1] = ptmp
-        perm_com = perm_g[len(perm_mix)-1]
-    #print "combined permutations are"; print perm_com
-
-    perm = perm_wrk*Nperm # generate perm_wrk "Nperm" times,
-    # say, [0,1,2,3,4,0,1,2,4,3,0,2,1,3,4,0,2,1,4,3]
-    for i in xrange(len(perm_com)):
-        for j in xrange(len(perm_com[0])):
-                perm[i*sz+perm_com[0][j]] = perm_com[i][j]
+        # now define the returned permutation
+        for i in xrange(sz_indx):
+            ix = s_col_indx[i]
+            iy = perm_res[i]
+            perm[ix] = iy
 
     return perm
 
@@ -225,34 +164,34 @@ def _test_setup():
 
     # non-identical matrix (corresponding to doubly mixed states)
     # | 1    0    0 0 |
-    # | 0 0.78 0.79 0 |
+    # | 0 0.76 0.79 0 |
     # | 0 0.79 0.80 0 |
     # | 0    0    0 1 |
 
     e = CMATRIX(4,4)
     e.set(0,0,1.0+0j);
-    e.set(1,1,0.78+0j); e.set(1,2,0.79+0j);
+    e.set(1,1,0.76+0j); e.set(1,2,0.79+0j);
     e.set(2,1,0.79+0j); e.set(2,2,0.80+0j);
     e.set(3,3,1.0+0j);
 
     # non-identical matrix (corresponding to triply mixed states)
     # | 1    0    0    0 0 |
-    # | 0 0.77 0.78 0.79 0 |
-    # | 0 0.78 0.79 0.81 0 |
-    # | 0 0.79 0.80 0.82 0 |
+    # | 0 0.71 0.75 0.77 0 |
+    # | 0 0.72 0.75 0.78 0 |
+    # | 0 0.73 0.76 0.80 0 |
     # | 0    0    0    0 1 |
 
     f = CMATRIX(5,5)
     f.set(0,0,1.0+0j);
-    f.set(1,1,0.77+0j); f.set(1,2,0.78+0j); f.set(1,3,0.79+0j);
-    f.set(2,1,0.78+0j); f.set(2,2,0.79+0j); f.set(2,3,0.81+0j);
-    f.set(3,1,0.79+0j); f.set(3,2,0.80+0j); f.set(3,3,0.82+0j);
+    f.set(1,1,0.71+0j); f.set(1,2,0.75+0j); f.set(1,3,0.77+0j);
+    f.set(2,1,0.72+0j); f.set(2,2,0.75+0j); f.set(2,3,0.78+0j);
+    f.set(3,1,0.73+0j); f.set(3,2,0.76+0j); f.set(3,3,0.80+0j);
     f.set(4,4,1.0+0j);
 
     # non-identical matrix (corresponding to 3 groups of doubly mixed states)
     # | 1    0    0    0    0    0    0|
     # | 0 0.73 0.75    0    0    0    0|
-    # | 0 0.74 0.76    0    0    0    0|
+    # | 0 0.76 0.76    0    0    0    0|
     # | 0    0    0 0.71 0.72    0    0|
     # | 0    0    0 0.74 0.78    0    0|
     # | 0    0    0    0    0 0.77 0.78|
@@ -261,7 +200,7 @@ def _test_setup():
     g = CMATRIX(7,7)
     g.set(0,0,1.0+0j);
     g.set(1,1,0.73+0j); g.set(1,2,0.75+0j);
-    g.set(2,1,0.74+0j); g.set(2,2,0.76+0j);
+    g.set(2,1,0.76+0j); g.set(2,2,0.76+0j);
     g.set(3,3,0.71+0j); g.set(3,4,0.72+0j);
     g.set(4,3,0.74+0j); g.set(4,4,0.78+0j);
     g.set(5,5,0.77+0j); g.set(5,6,0.78+0j);
@@ -269,16 +208,16 @@ def _test_setup():
 
     # non-identical matrix (corresponding to triply mixed states)
     # | 1    0    0    0 0 |
-    # | 0 0.77 0.78 0.65 0 |
+    # | 0 0.77 0.78 0.78 0 |
     # | 0 0.76 0.75 0.89 0 |
-    # | 0 0.65 0.54 0.77 0 |
+    # | 0 0.75 0.73 0.77 0 |
     # | 0    0    0    0 1 | 
 
     h = CMATRIX(5,5)
     h.set(0,0,1.0+0j);
-    h.set(1,1,0.77+0j); h.set(1,2,0.78+0j); h.set(1,3,0.65+0j);
+    h.set(1,1,0.77+0j); h.set(1,2,0.78+0j); h.set(1,3,0.78+0j);
     h.set(2,1,0.76+0j); h.set(2,2,0.75+0j); h.set(2,3,0.89+0j);
-    h.set(3,1,0.65+0j); h.set(3,2,0.54+0j); h.set(3,3,0.77+0j);
+    h.set(3,1,0.75+0j); h.set(3,2,0.73+0j); h.set(3,3,0.77+0j);
     h.set(4,4,1.00+0j);
 
     # non-identical matrix (corresponding to triply mixed states)
@@ -321,31 +260,30 @@ class TestUnavoided(unittest.TestCase):
         perm_e = get_reordering(e)
         print "Input matrix "; e.show_matrix()
         print "Permutation = ", perm_e
-        self.assertEqual(perm_e, [0,1,2,3,0,2,1,3])
+        self.assertEqual(perm_e, [0,2,1,3])
 
         perm_f = get_reordering(f)
         print "Input matrix "; f.show_matrix()
         print "Permutation = ", perm_f
-        perm_f_eq = [0, 1, 2, 3, 4, 0, 1, 3, 2, 4, 0, 2, 1, 3, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 3, 2, 1, 4]
+        perm_f_eq = [0, 2, 1, 3, 4]
         self.assertEqual(perm_f, perm_f_eq)
 
         perm_g = get_reordering(g)
         print "Input matrix "; g.show_matrix()
         print "Permutation = ", perm_g
-        perm_g_eq = [0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 6, 5, 0, 1, 2, 4, 3, 5, 6, 0, 1, 2, 4, 3, 6, 5,\
-                         0, 2, 1, 3, 4, 5, 6, 0, 2, 1, 3, 4, 6, 5, 0, 2, 1, 4, 3, 5, 6, 0, 2, 1, 4, 3, 6, 5]
+        perm_g_eq = [0, 2, 1, 3, 4, 5, 6]
         self.assertEqual(perm_g, perm_g_eq)
 
         perm_h = get_reordering(h)
         print "Input matrix "; h.show_matrix()
         print "Permutation = ", perm_h
-        perm_h_eq = [0, 1, 2, 3, 4, 0, 1, 3, 2, 4, 0, 2, 1, 3, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 3, 2, 1, 4]
+        perm_h_eq = [0, 2, 3, 1, 4]
         self.assertEqual(perm_h, perm_h_eq)
 
         perm_h1 = get_reordering(h1)
         print "Input matrix "; h1.show_matrix()
         print "Permutation = ", perm_h1
-        perm_h1_eq = [0, 1, 2, 3, 4, 0, 3, 2, 1, 4, 0, 1, 3, 2, 4, 0, 2, 3, 1, 4, 0, 3, 1, 2, 4, 0, 2, 1, 3, 4]
+        perm_h1_eq = [0, 2, 1, 3, 4]
         self.assertEqual(perm_h1, perm_h1_eq)
 
 if __name__=='__main__':

--- a/src/unavoided_tmp.py
+++ b/src/unavoided_tmp.py
@@ -125,10 +125,16 @@ def get_reordering(time_overlap):
                 # check if this loop ends or not.
                 cnt+=1
                 if cnt > sz:
+                    print "***********************************************"
                     print "reordering counts reached the given threshold "
-                    print "The matrix is "; S.show_matrix();
-                    print "The (col,indx) pair is (%i,%i)" % (col,indx)
+                    print "The original matrix is "; time_overlap.show_matrix();
+                    print "row numbers indicating maximum value of each column are"; print perm_ini;
+                    print "duplicate numbers are"; print du;
+                    print "column numbers for escaping from reordering are"; print esc;
+                    print "The reordered matrix is"; S.show_matrix();
+                    print "The (col,indx) pair occuring errors is (%i,%i)" % (col,indx)
                     print "exitting..."; sys.exit(0)
+
     #print "After being reordered, the working permutation is"; print perm_wrk
 
     ''' Then, all posible permutations will be generated. '''

--- a/src/x_to_libra_gms.py
+++ b/src/x_to_libra_gms.py
@@ -131,16 +131,8 @@ def gamess_to_libra(params, ao, E, sd_basis, active_space,suff):
         print "trivial crossings occured!"
         print "perm is", perm
         print "P12 is"; P12.show_matrix()
-        ksi = rnd.uniform(0.0,1.0)
-        Np = len(perm)/nstates
-        ip = int(Np*ksi)
-        istart = ip*nstates
-        iend = (ip+1)*nstates
-        ptmp = perm[istart:iend]
-        print "The selected number is %i" % ip
-        print "selected permutation is "; print ptmp
 
-        reorder_matrices.reorder(ptmp,P12,E2)
+        reorder_matrices.reorder(perm,P12,E2)
         P21 = P12.H()
 
     # calculate transition dipole moment matrices in the MO basis:


### PR DESCRIPTION
A permutation indicating how to reorder states should be satisfied with the condition where a trace of the corresponding density matrix becomes maximum value of all possible matrices. This idea is followed by this modification.  Now, we don't need to use random numbers for obtaining all possible permutations.
Although this code is not seen clearly, we can uniquely reorder all kinds of matrices.