### PR TITLE
NA-MD in the case where electronic back reaction is not included can be executed with low computational cost.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ slurm*
 *.dat
 Ham_*
 *wrk.inp
-run/H2O_wrk.inp
 *.nfs*
 re_*
 im_*
@@ -27,5 +26,5 @@ wfc*
 *.err
 *_re_*
 *_im_*
-
+hop_probs
 

--- a/run/gms/run_gms.py
+++ b/run/gms/run_gms.py
@@ -139,6 +139,12 @@ params["excitations"] = [ excitation(0,1,0,1), excitation(0,1,1,1), excitation(-
 #params["excitations"] = [ excitation(0,1,0,1)]
 params["excitations_init"] = [0]
 
+# shifting energies. The values must be defined in eV unit. This is optional; you can delete this parameter.
+params["shift_E"] = [27.2116, 0.0, 0.0] # shifts diagonal elements of vibronic hamiltonian (exciting energies).
+                                  # If it is defined as [a, b, c], then exciting energies E0, E1, E2 are shifted
+                                  # E0 -> E0 + a, E1 -> E1 + b, E2 -> E2 + c
+                                  # Keep in mind that the length of this list must be equal to that of "excitations" list.
+
 # create thermostat
 params["therm"] = Thermostat({"thermostat_type":"Nose-Hoover","nu_therm":0.001,"Temperature":300.0,"NHC_size":5})
 params["Temperature"] = params["therm"].Temperature # explicitly defined

--- a/run/gms/run_gms.py
+++ b/run/gms/run_gms.py
@@ -127,6 +127,7 @@ params["el_mts"] = 1                   # electronic time steps per one nuclear t
 params["rep"] = 0                      # representation: 0 - diabatic, 1 - adiabatic
 params["num_SH_traj"] = 1              # number of excited states trajectories per initial nuclei geometry and excited states
 params["smat_inc"] = 0                 # 1 Including overlap matrix (S), 0 when overlap matrix (S) not included in el propagation
+params["do_rescaling"] = 1
 
 # ***************************************************************
 
@@ -140,10 +141,10 @@ params["excitations"] = [ excitation(0,1,0,1), excitation(0,1,1,1), excitation(-
 params["excitations_init"] = [0]
 
 # shifting energies. The values must be defined in eV unit. This is optional; you can delete this parameter.
-params["shift_E"] = [27.2116, 0.0, 0.0] # shifts diagonal elements of vibronic hamiltonian (exciting energies).
-                                  # If it is defined as [a, b, c], then exciting energies E0, E1, E2 are shifted
-                                  # E0 -> E0 + a, E1 -> E1 + b, E2 -> E2 + c
-                                  # Keep in mind that the length of this list must be equal to that of "excitations" list.
+params["shift_E"] = [0.0, 0.0, 0.0] # shifts diagonal elements of vibronic hamiltonian (exciting energies).
+                                    # If it is defined as [a, b, c], then exciting energies E0, E1, E2 are shifted
+                                    # E0 -> E0 + a, E1 -> E1 + b, E2 -> E2 + c
+                                    # Keep in mind that the length of this list must be equal to that of "excitations" list.
 
 # create thermostat
 params["therm"] = Thermostat({"thermostat_type":"Nose-Hoover","nu_therm":0.001,"Temperature":300.0,"NHC_size":5})

--- a/src/defaults.py
+++ b/src/defaults.py
@@ -60,6 +60,8 @@ def set_defaults(params, interface, recipe=""):
     # directory where SD basis vibronic hamiltonians will be printed out
     params["sd_ham"] = cwd+"/sd_ham/" 
 
+    # directory where hop probabilities will be printed out
+    params["hop_probs"] = cwd+"/hop_probs/"
 
     if interface=="QE":
         # The file into which the MD trajectorie will be printed out

--- a/src/extract_gms.py
+++ b/src/extract_gms.py
@@ -217,10 +217,10 @@ def gms_extract_mo(inp_str,Ngbf,active_space,flag):
         print "active space is not defined correctly, exit....."
         sys.exit(0)
 
-    E = MATRIX(sz,sz)
-    for i in xrange(sz):
-        imo = active_space[i]-1
-        E.set(i,i,E_full.get(imo,imo))
+    #E = MATRIX(sz,sz)
+    #for i in xrange(sz):
+    #    imo = active_space[i]-1
+    #    E.set(i,i,E_full.get(imo,imo))
 
     #C = CMATRIX(C_full) # input full matrix
     C = CMATRIX(Ngbf,sz)
@@ -241,10 +241,10 @@ def gms_extract_mo(inp_str,Ngbf,active_space,flag):
         print "C_full(Ngbf-1,Ngbf-1) is",C_full.get(Ngbf-1,Ngbf-1)
         print "*** reduced matrix ****"
         print "active_space=",active_space
-        print "E Matrix is"; E.show_matrix()
+        #print "E Matrix is"; E.show_matrix()
         print "C Matrix is"; C.show_matrix()
 
-    return E, C
+    return E_full, C
     
 def gms_extract_coordinates(inp_str,flag):
     ##
@@ -362,15 +362,23 @@ def gms_extract(filename,states,min_shift,active_space,flag):
     # the total energies of excited states (1-electron basis)
 
     # *********Here, KS excitation energy -> total excitation energy***************
+    homo = active_space[0] - min_shift # HOMO : number ordering starts from 1, not 0.
     nstates = len(states)
     E = MATRIX(nstates,nstates)
     for i in xrange(nstates):
-        h_indx = states[i].from_orbit[0] - min_shift  # index of the hole orbital w.r.t. the lowest included in the active space orbital
-        e_indx = states[i].to_orbit[0]   - min_shift  # --- same, only for the electron orbital
+        #h_indx = states[i].from_orbit[0] - min_shift  # index of the hole orbital w.r.t. the lowest included in the active space orbital
+        #e_indx = states[i].to_orbit[0]   - min_shift  # --- same, only for the electron orbital
+        print "%i th excitation" %(i)
+        h_indx = states[i].from_orbit[0] + homo - 1
+        e_indx = states[i].to_orbit[0] + homo - 1
         EX_ene = info["tot_ene"] + E_MO.get(e_indx,e_indx) - E_MO.get(h_indx,h_indx) # excitation energy
         #EX_ene = info["tot_ene"] # for debugging MD without electron dynamics 
         E.set(i,i,EX_ene)
-
+        if 0==1: # debug
+            print "e_indx is %i" %(e_indx)
+            print "MO energy is %f" %( E_MO.get(e_indx,e_indx))
+            print "h_indx is %i" %(h_indx)
+            print "MO energy is %f" %( E_MO.get(h_indx,h_indx))
     # ******************************************************************************
 
     if flag == 1:

--- a/src/extract_gms.py
+++ b/src/extract_gms.py
@@ -368,7 +368,7 @@ def gms_extract(filename,states,min_shift,active_space,flag):
     for i in xrange(nstates):
         #h_indx = states[i].from_orbit[0] - min_shift  # index of the hole orbital w.r.t. the lowest included in the active space orbital
         #e_indx = states[i].to_orbit[0]   - min_shift  # --- same, only for the electron orbital
-        print "%i th excitation" %(i)
+        #print "%i th excitation" %(i)
         h_indx = states[i].from_orbit[0] + homo - 1
         e_indx = states[i].to_orbit[0] + homo - 1
         EX_ene = info["tot_ene"] + E_MO.get(e_indx,e_indx) - E_MO.get(h_indx,h_indx) # excitation energy

--- a/src/hamiltonian_vib.py
+++ b/src/hamiltonian_vib.py
@@ -308,8 +308,9 @@ def update_vibronic_hamiltonian(ham_el, ham_vib, params,E_SD,nac,suffix, opt):
     if "inactive_states" in params:
         for ist in params["inactive_states"]:
             for jst in xrange(nstates):
-                ham_vib.set(ist,jst, 0.0, 0.0)
-                ham_vib.set(jst,ist, 0.0, 0.0)
+                if ist!=jst:
+                    ham_vib.set(ist,jst, 0.0, 0.0)
+                    ham_vib.set(jst,ist, 0.0, 0.0)
 
     if params["print_sd_ham"] == 1:
         ham_vib.real().show_matrix(params["sd_ham"] + "Ham_vib_re_" + suffix)

--- a/src/hamiltonian_vib.py
+++ b/src/hamiltonian_vib.py
@@ -304,6 +304,13 @@ def update_vibronic_hamiltonian(ham_el, ham_vib, params,E_SD,nac,suffix, opt):
                     ham_vib.set(I,J,(-1.0j+0.0)*nac.get(I,J))
                     print "\n"
       
+
+    if "inactive_states" in params:
+        for ist in params["inactive_states"]:
+            for jst in xrange(nstates):
+                ham_vib.set(ist,jst, 0.0, 0.0)
+                ham_vib.set(jst,ist, 0.0, 0.0)
+
     if params["print_sd_ham"] == 1:
         ham_vib.real().show_matrix(params["sd_ham"] + "Ham_vib_re_" + suffix)
         ham_vib.imag().show_matrix(params["sd_ham"] + "Ham_vib_im_" + suffix)

--- a/src/main.py
+++ b/src/main.py
@@ -91,7 +91,7 @@ def sanity_check(params):
 
         if "therm" in params.keys():    
             if params["therm"] == None:
-                print "NVT simulations reuire some valid thermostat. None is given. Exiting..."
+                print "NVT simulations require some valid thermostat. None is given. Exiting..."
                 sys.exit(0)
         else:
             print "NVT simulations require thermostat! Use \"therm\" keyword. Exiting..."
@@ -344,7 +344,7 @@ def main(params):
                         print "is_MM is set to 1, which means you need to provide the \
                         a file containing the connectivity information for your MM system. \
                         As of now, such file is called = ", params["ent_file"], " but it cannot \
-                        be found on your system. Pease check if it exists or set is_MM to 0. \
+                        be found on your system. Please check if it exists or set is_MM to 0. \
                         Exiting..."
                         sys.exit(0)
 

--- a/src/main.py
+++ b/src/main.py
@@ -125,8 +125,9 @@ def main(params):
     if SH_type >= 1: # calculate no SH probs.  
         num_SH_traj = params["num_SH_traj"]
 
-    ntraj = nstates_init*ninit*num_SH_traj
-
+    ntraj = ninit*nstates_init
+    if params["do_rescaling"] == 1: # nuclear trajectory depends eletronic hops.
+        ntraj = ninit*nstates_init*num_SH_traj
 
 
     active_space = []
@@ -327,10 +328,13 @@ def main(params):
     if params["MD_type"] == 1: # start NA-MD interacting with thermostat @ t=0
         Ttemp = params["Temperature"]
 
-    # all excitations for each nuclear configuration
+    # create system object
+    Nsh = 1
+    if params["do_rescaling"] == 1:
+        Nsh = num_SH_traj
     for i in xrange(ninit):
         for i_ex in params["excitations_init"]:
-            for itraj in xrange(num_SH_traj):
+            for itraj in xrange(Nsh):
                 df = 0 # debug flag
                 # Here we use libra_py module!
                 # Utilize the gradients on the ground (0) excited state
@@ -350,8 +354,14 @@ def main(params):
 
                 syst.append(x)
 
+    # all excitations for each nuclear configuration
+    for i in xrange(ninit):
+        for i_ex in params["excitations_init"]:
+            for itraj in xrange(num_SH_traj):
                 el.append(Electronic(nstates,i_ex))
-    
+
+
+    #sys.exit(0) # debug
     # set list of SH state trajectories
     print "run MD"
     run_MD(syst,el,ao_list,e_list,sd_basis_list,params,label_list, Q_list, active_space)

--- a/src/md.py
+++ b/src/md.py
@@ -434,6 +434,7 @@ def run_MD(syst,el,ao,E,sd_basis,params,label,Q, active_space):
             print "time before TSH=",t.show(),"sec"
 
             if SH_type>=1 and params["Nstart"] < i:
+                params["time_step"] = ij # for numbering the transition probability.
                 if params["interface"]=="GAMESS":
                     if params["do_rescaling"] == 1: # default
                         tsh.surface_hopping_cpa2(mol, el, ham, rnd, params) # velocity rescaling is done.

--- a/src/md.py
+++ b/src/md.py
@@ -437,7 +437,7 @@ def run_MD(syst,el,ao,E,sd_basis,params,label,Q, active_space):
                 if params["interface"]=="GAMESS":
                     if params["do_rescaling"] == 1: # default
                         tsh.surface_hopping_cpa2(mol, el, ham, rnd, params) # velocity rescaling is done.
-                    elif params["do_rescaling"] == 0:
+                    else:
                         tsh.surface_hopping_cpa(mol, el, ham, rnd, params) # velocity rescaling is not done; Electronic back reaction is neglected.
                 if params["interface"]=="G09":
                     tsh.surface_hopping_cpa2(mol, el, ham, rnd, params) # velocity rescaling is done.
@@ -451,14 +451,15 @@ def run_MD(syst,el,ao,E,sd_basis,params,label,Q, active_space):
                         cnt = iconf*nstates_init + i_ex
                         for itraj in xrange(num_SH_traj):
                             cnt_inc_el = iconf*nstates_init*num_SH_traj + i_ex*num_SH_traj + itraj
+
                             if params["do_rescaling"] == 1:
                                 cnt = cnt_inc_el
 
-                                new_st = el[cnt_inc_el].istate
-                                ksi = rnd.uniform(0.0, 1.0)
-                                E_old = ham_vib[cnt].get(old_st[cnt_inc_el],old_st[cnt_inc_el]).real
-                                E_new = ham_vib[cnt].get(new_st,new_st).real
-                                el[cnt_inc_el].istate, el[cnt_inc_el] = tsh.ida_py(el[cnt_inc_el], old_st[cnt_inc_el], new_st, E_old, E_new, params["Temperature"], ksi, params["do_collapse"]) 
+                            new_st = el[cnt_inc_el].istate
+                            ksi = rnd.uniform(0.0, 1.0)
+                            E_old = ham_vib[cnt].get(old_st[cnt_inc_el],old_st[cnt_inc_el]).real
+                            E_new = ham_vib[cnt].get(new_st,new_st).real
+                            el[cnt_inc_el].istate, el[cnt_inc_el] = tsh.ida_py(el[cnt_inc_el], old_st[cnt_inc_el], new_st, E_old, E_new, params["Temperature"], ksi, params["do_collapse"]) 
             ################### END of TSH ##########################
             print "Finished TSH"
             t.stop()
@@ -472,7 +473,7 @@ def run_MD(syst,el,ao,E,sd_basis,params,label,Q, active_space):
             if i <= params["Ncool"]:
                 Nsys = ntraj
                 if params["do_rescaling"] == 1:
-                    Nsys = num_SH_traj
+                    Nsys = ntraj * num_SH_traj
                 for cnt in xrange(Nsys):
                     syst[cnt].cool()
                     syst[cnt].extract_atomic_p(mol[cnt].p)  # syst -> mol

--- a/src/print_results.py
+++ b/src/print_results.py
@@ -121,9 +121,12 @@ def print_ens_traj(isnap,mol,syst,mu,epot,ekin,etot,eext,params):
 
     for iconf in xrange(nconfig):
         for i_ex in xrange(nstates_init):
+            cnt = iconf*nstates_init + i_ex
             for itraj in xrange(num_SH_traj):
 
-                cnt = iconf*nstates_init*num_SH_traj + i_ex*num_SH_traj + itraj
+                cnt_inc_el = iconf*nstates_init*num_SH_traj + i_ex*num_SH_traj + itraj
+                if params["do_rescaling"] ==1:
+                    cnt = cnt_inc_el
                 print_one_traj(isnap,iconf,params["excitations_init"][i_ex],itraj,mol[cnt],syst[cnt],mu[cnt],epot[cnt], ekin[cnt], etot[cnt], eext[cnt],params)
 
 

--- a/src/x_to_libra_gms.py
+++ b/src/x_to_libra_gms.py
@@ -69,7 +69,7 @@ def exe_gamess(params):
 def gamess_to_libra(params, ao, E, sd_basis, active_space,suff):
     ## 
     # Finds the keywords and their patterns and extracts the parameters
-    # \param[in] params         contains input parameters , in the directory form
+    # \param[in] params         contains input parameters , in the dictionary form
     # \param[in,out] ao         atomic orbital basis at "t" old
     # \param[in,out] E          total excitation energies at "t" old
     # \param[in] sd_basis       Basis of Slater determinants at "t" old (list of CMATRIX object).
@@ -171,6 +171,15 @@ def gamess_to_libra(params, ao, E, sd_basis, active_space,suff):
     # Here, explicit computation would be more convinient than using outer functions (in hamiltonian_el.py).
     E_ave = 0.50 * ( E + E2 )
     nac = 0.50/params["dt_nucl"] * ( P12 - P21 )
+
+    # shift exciting energies according to "shift_E" list.
+    if "shift_E" in params:
+        eV_to_au = 0.036749
+        #print "before shifting E(0,0) is %f " % E_ave.get(0,0)
+        for i in xrange(nstates):
+            etmp = E_ave.get(i,i) + params["shift_E"][i]*eV_to_au
+            E_ave.set(i, i, etmp)
+        #print "after shifting E(0,0) is %f " % E_ave.get(0,0)
 
     # here, E_ave and nac are printed for debugging 
     #if 0==1:


### PR DESCRIPTION
# Major change
So far, the program has been coded to execute NA-MD in the case where electronic back reaction is included. 
 However, as a defect, it is not proper when executing NA-MD in another case: the back reaction is not included. In this case, we can't reduce the number of SCF calculation which needs the largest amount of time. For reducing the computational cost in such NA-MD, the program was modified. 
This modification uses an input parameter `params["do_rescaling"] ` ; that will change the number of SCF calculation.
If `params["do_rescaling"] =1` (as a default), the number is the same as that of TSH trajectories. Otherwise, the number is less than that of TSH trajectories.
Following this update, the code https://github.com/kosukesato/libra-code/blob/devel/src/libra_py/tsh.py was modified, too. I'll do pull-request about that modification if this pull-request is allowed to be merged.

# Minor change
`params["shift_E"]` was defined to shift excitation energies as we need. Note that the parameter influences only Libra-GAMESS part, and we don't have to set this parameter when we don't want to.